### PR TITLE
updated output to include commercial timeperiod and a "< X" line as well

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ const styles = `
   fill: #5fa04e;
 }
 .commercial {
-  fill: #eb6d27;
+  fill: #ae5f00;
 }
 .active {
   fill: #229ad6;

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,9 @@ const styles = `
 .current {
   fill: #5fa04e;
 }
+.commercial {
+  fill: #eb6d27;
+}
 .active {
   fill: #229ad6;
 }
@@ -38,11 +41,11 @@ const styles = `
   text-transform: uppercase;
 }`;
 
-
+///
 function parseInput (data, queryStart, queryEnd, excludeMaster, projectName) {
   const output = [];
 
-  Object.keys(data).forEach((v) => {
+  Object.keys(data).reverse().forEach((v) => {
     const version = data[v];
     const name = `${projectName} ${v.replace('v', '')}`;
     const current = version.start ? new Date(version.start) : null;
@@ -56,6 +59,12 @@ function parseInput (data, queryStart, queryEnd, excludeMaster, projectName) {
 
     if (end === null) {
       throw new Error(`missing end in ${version}`);
+    }
+
+    if (active !== null) {
+      if (maint < queryEnd && end > queryStart) {
+        output.push({ name, type: 'commercial', start: end, end: queryEnd });
+      }
     }
 
     if (maint !== null) {
@@ -80,16 +89,32 @@ function parseInput (data, queryStart, queryEnd, excludeMaster, projectName) {
   });
 
   if (!excludeMaster) {
+    AddFullLineToTop(output, 'Main', 'unstable',);
+  }
+
+  AddFullLineToBottom(output, '<= v16', 'commercial');
+
+  return output;
+
+  function AddFullLineToTop(output, name, type) {
     output.unshift({
-      name: 'Master',
-      type: 'unstable',
+      name: name,
+      type: type,
       start: queryStart,
       end: queryEnd
     });
   }
-
-  return output;
+  function AddFullLineToBottom(output, name, type, start, end) {
+    output.push({
+      name: name,
+      type: type,
+      start: queryStart,
+      end: queryEnd
+    });
+  }
 }
+
+
 
 
 function create (options) {
@@ -103,6 +128,7 @@ function create (options) {
                    .domain([queryStart, queryEnd])
                    .range([0, width])
                    .clamp(true);
+  // console.log(data.map((data) => { return data.type; }));
   const yScale = D3.scaleBand()
                    .domain(data.map((data) => { return data.name; }))
                    .range([0, height])
@@ -117,7 +143,6 @@ function create (options) {
                  .append('g')
                  .attr('id', 'bar-container')
                  .attr('transform', `translate(${margin.left}, ${margin.top})`);
-
 
   function calculateWidth (data) {
     return xScale(data.end) - xScale(data.start);


### PR DESCRIPTION
added a bar for commercial time period per conversation on nodejs-tsc-herodevs slack and approval of this graphic: 
![node-release](https://github.com/user-attachments/assets/bd824dfc-8dd0-496d-92ac-637d79280373)
