### PR TITLE
chore(meta)!: rename the package to `@node-code/lts-schedule`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lts",
+  "name": "@node-code/lts-schedule",
   "version": "2.0.0",
   "description": "Generate the Node.js LTS schedule",
   "main": "lib/index.js",


### PR DESCRIPTION
Currently, the repo is named `nodejs/lts-schedule` but the npm package is named [`lts`](https://www.npmjs.com/package/lts), which is confusing – even more considering there's another [`lts-schedule`](https://www.npmjs.com/package/lts-schedule) on npm which is a separate project (looking at https://github.com/ralphtheninja/lts-schedule/commits/master/, it seems there are no commits in common, it was started a few months after this repo and seems to be heavily influenced by it as it seemingly tries to achieve the same goal with a similar API).

Let's rename it under our `@node-code/` prefix, and name it like the repo to keep confusion to a minimal.